### PR TITLE
added auth failure handling upon connection setup

### DIFF
--- a/mongo_core/mongo_full.py
+++ b/mongo_core/mongo_full.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from IPython.core.magic import (magics_class, line_cell_magic)
+from pymongo.errors import OperationFailure, ConnectionFailure
 from mongo_core._version import __desc__
 from integration_core import Integration
 import jupyter_integrations_utility as jiu
@@ -124,7 +125,17 @@ class Mongo(Integration):
                     **inst["options"]
                 )
 
+                inst["session"].session.admin.command("ismaster")
+
                 result = 0
+
+            except OperationFailure as e:
+                if "Authentication failed" in str(e):
+                    jiu.display_error("Error: Authentication failed. Please check your username and password.")
+                else:
+                    jiu.display_error(f"An operation error occurred: {e}")
+            except ConnectionFailure as e:
+                jiu.display_error(f"Failed to connect to MongoDB. Error: {e}")
 
             except Exception as e:
                 jiu.display_error(e)


### PR DESCRIPTION
# What is the problem?
- When `handleCell` is called from a cell magic, it doesn't raise a handled exception. As a result, if a user mistypes their password to the Mongo instance, they receive an unhandled exception that makes no sense to them, or us as developers.
- ![image](https://github.com/user-attachments/assets/cc761bb0-d1f5-4d28-9476-fa5b98423393)

# What changed?
- added a simple connection test when the user goes to connect to a Mongo instance. It issues a simple `"ismaster"` command which forces the connection to connect. If it fails, it will properly raise an authentication error to the user